### PR TITLE
#1 - Upgrade to .NET Framework 4.8 and update dependencies

### DIFF
--- a/PDF_Content_vs_Filename_Checker/App.config
+++ b/PDF_Content_vs_Filename_Checker/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/PDF_Content_vs_Filename_Checker/PDF_Content_vs_Filename_Checker.csproj
+++ b/PDF_Content_vs_Filename_Checker/PDF_Content_vs_Filename_Checker.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>PDF_Content_vs_Filename_Checker</RootNamespace>
     <AssemblyName>PDF_Content_vs_Filename_Checker</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -49,8 +49,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto, Version=1.8.6.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <HintPath>..\packages\BouncyCastle.1.8.6.1\lib\BouncyCastle.Crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Cryptography, Version=2.0.0.0, Culture=neutral, PublicKeyToken=072edcf4a5328938, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.Cryptography.2.6.2\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
     </Reference>
     <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <HintPath>..\packages\Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
@@ -58,8 +58,8 @@
     <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <HintPath>..\packages\Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="itextsharp, Version=5.5.13.2, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
-      <HintPath>..\packages\iTextSharp.5.5.13.2\lib\itextsharp.dll</HintPath>
+    <Reference Include="itextsharp, Version=5.5.13.4, Culture=neutral, PublicKeyToken=8354ae6d2174ddca, processorArchitecture=MSIL">
+      <HintPath>..\packages\iTextSharp.5.5.13.4\lib\net461\itextsharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/PDF_Content_vs_Filename_Checker/packages.config
+++ b/PDF_Content_vs_Filename_Checker/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle" version="1.8.6.1" targetFramework="net48" />
+  <package id="BouncyCastle.Cryptography" version="2.6.2" targetFramework="net48" />
   <package id="Common.Logging" version="3.4.1" targetFramework="net48" />
   <package id="Common.Logging.Core" version="3.4.1" targetFramework="net48" />
-  <package id="iTextSharp" version="5.5.13.2" targetFramework="net48" />
-  <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net48" />
-  <package id="Portable.BouncyCastle" version="1.8.5" targetFramework="net48" />
+  <package id="iTextSharp" version="5.5.13.4" targetFramework="net48" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net48" />
+  <package id="Portable.BouncyCastle" version="1.9.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Upgraded the project from .NET Framework 4.6 to 4.8 for improved compatibility and performance.

Replaced `BouncyCastle.Crypto` (v1.8.6.0) with `BouncyCastle.Cryptography` (v2.0.0.0) and updated the `HintPath` in the project file.

Updated `iTextSharp` from v5.5.13.2 to v5.5.13.4 and adjusted the `HintPath` accordingly.

Modified `packages.config` to reflect the following package updates:
- Replaced `BouncyCastle` (v1.8.6.1) with `BouncyCastle.Cryptography` (v2.6.2).
- Updated `Microsoft.CSharp` from v4.0.1 to v4.7.0.
- Updated `Portable.BouncyCastle` from v1.8.5 to v1.9.0.

These changes address potential security vulnerabilities, improve functionality, and ensure compatibility with modern development standards.